### PR TITLE
Ship movement

### DIFF
--- a/src/game/actor/mod.rs
+++ b/src/game/actor/mod.rs
@@ -38,6 +38,7 @@ pub struct StarRustSceneBundle {
 #[derive(Bundle, Clone)]
 pub struct ActorBundle {
     pub actor: Actor,
+    pub wanted_direction: WantedDirection,
     pub scene_bundle: StarRustSceneBundle,
     pub collider: Collider,
     pub health: Health,

--- a/src/game/actor/ship.rs
+++ b/src/game/actor/ship.rs
@@ -25,6 +25,7 @@ impl BundledActor<PlayerActorBundle> for PlayerShipDefault {
                 actor: Actor {
                     speed: Vec2::new(6.0, 6.0),
                 },
+                wanted_direction: default(),
                 scene_bundle: StarRustSceneBundle {
                     scene: models.default_player.clone(),
                     transform: Transform::from_xyz(spawn_position.x, spawn_position.y, 2.0)
@@ -73,6 +74,7 @@ impl BundledActor<AiActorBundle> for DefaultEnemyShip {
                 actor: Actor {
                     speed: Vec2::new(1.5, 1.5),
                 },
+                wanted_direction: default(),
                 scene_bundle: StarRustSceneBundle {
                     scene: models.default_enemy.clone(),
                     transform: Transform::from_xyz(spawn_position.x, spawn_position.y, 2.0)

--- a/src/game/components.rs
+++ b/src/game/components.rs
@@ -15,6 +15,8 @@ pub struct Enemy;
 pub struct Actor {
     pub speed: Vec2,
 }
+#[derive(Component, Clone, Default)]
+pub struct WantedDirection(pub Vec2);
 
 #[derive(Component, Clone)]
 pub struct Health {

--- a/src/game/vfx/mod.rs
+++ b/src/game/vfx/mod.rs
@@ -60,7 +60,7 @@ fn shake_camera(
             t.translation = Vec3::new(
                 magnitude_at_time * theta.cos(),
                 magnitude_at_time * theta.sin(),
-                CAMERA_FAR,
+                CAMERA_FAR - 100f32,
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn setup_camera(mut commands: Commands) {
                 scale: 1.0,
                 ..default()
             }),
-            transform: Transform::from_xyz(0.0, 0.0, CAMERA_FAR - 0.1)
+            transform: Transform::from_xyz(0.0, 0.0, CAMERA_FAR - 10f32)
                 .looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         })


### PR DESCRIPTION
I'm familiarizing with the codebase by implementing random features, let me know if anything is useful to you:

### Done so far

- player movement independent from FPS by using time resource
- small rotation of the player ship if going up or down ; a side effect is that we now shoot up or down, I quite liked it as it makes the game a bit easier, but eventually we could force a shoot straight..

### Ideas for other improvements;
- we could share movement code between ai and player by reusing WantedMovement
- fire reactor particles when going right ? another particle effect when going left ?
- ships are cut in half, I'm not sure why, but probably the camera far plane is cutting them, or there is a background hiding them 🤔 
- explosion of the ship, with a freeze à la https://www.youtube.com/watch?v=OdVkEOzdCPw&t=3s

### Current state as a gif:

https://user-images.githubusercontent.com/2290685/200613641-bf97fd12-bb41-4c8a-a914-e1ffc62f9573.mp4

