### PR TITLE
Bevy Hanabi support 0.12.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.14.2"
+bevy_hanabi = "0.12.2"
 fastrand = "1.9.0" # ref: https://github.com/bevyengine/bevy/pull/3992
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ NOTE (8/4/2023): This project is generally shelved until Bevy is more mature. Na
 TODO:
 
 - [x] Rework spawning to allow for arbritrary types to spawn.
-- [ ] Adopt Bevy Hanabi particle system once [WASM compatibility is implemented](https://github.com/djeedai/bevy_hanabi/issues/41)
+- [x] Adopt Bevy Hanabi particle system once [WASM compatibility is implemented](https://github.com/djeedai/bevy_hanabi/issues/41)
+  - [ ] Explosions should have a velocity
+  - [ ] Explosions should have a dedicated component.
 - [ ] Setup Shader instancing for 3d Models
 - [ ] UI
   - [ ] Player Healthbar

--- a/src/game/collisions.rs
+++ b/src/game/collisions.rs
@@ -92,7 +92,7 @@ pub fn check_collisions(
                         });
                         explosion_event.send(ExplosionEvent {
                             position: b_transform.translation,
-                            lifetime: 0.25,
+                            lifetime: 1.0, // TODO: Add this param to a component
                         });
                     }
 

--- a/src/game/collisions.rs
+++ b/src/game/collisions.rs
@@ -92,7 +92,7 @@ pub fn check_collisions(
                         });
                         explosion_event.send(ExplosionEvent {
                             position: b_transform.translation,
-                            lifetime: 1.0, // TODO: Add this param to a component
+                            lifetime: 0.3, // TODO: Add this param to a component
                         });
                     }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -11,6 +11,7 @@ mod audio;
 pub use audio::*;
 
 mod constants;
+use bevy_hanabi::HanabiPlugin;
 use constants::*;
 
 mod player;
@@ -20,10 +21,8 @@ mod collisions;
 pub use collisions::*;
 
 mod health;
-pub use health::*;
 
 pub mod components;
-pub use components::Player;
 
 mod events;
 
@@ -58,6 +57,7 @@ pub struct GamePlugin;
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
+            HanabiPlugin,
             ModelsPlugin,
             BackgroundPlugin,
             UiPlugin,

--- a/src/game/models/mod.rs
+++ b/src/game/models/mod.rs
@@ -24,8 +24,6 @@ pub struct ModelsAssets {
     pub powerup_ico: Handle<Scene>,
 }
 
-
-
 pub fn setup_resources(mut commands: Commands, asset_server: ResMut<AssetServer>) {
     let scene_assets = ModelsAssets {
         default_player: asset_server.load("models/basic_hero.glb#Scene0"),

--- a/src/game/vfx/mod.rs
+++ b/src/game/vfx/mod.rs
@@ -86,7 +86,7 @@ fn on_explosion_event(
         let init_vel = SetVelocityCircleModifier {
             center: module.lit(Vec3::ZERO),
             axis: module.lit(Vec3::new(0., 0., 1.)),
-            speed: module.lit(400.0),
+            speed: module.lit(1000.0),
         };
 
 

--- a/src/game/vfx/mod.rs
+++ b/src/game/vfx/mod.rs
@@ -2,16 +2,12 @@ use std::f32::consts::PI;
 
 use crate::constants::CAMERA_FAR;
 use bevy::{prelude::*, utils::Duration};
-//use bevy_particle_systems::*;
 
-//use bevy_hanabi::ParticleEffect;
-//use bevy_hanabi::ParticleLifetimeModifier;
-//use bevy_hanabi::PositionCircleModifier;
-//use bevy_hanabi::SizeOverLifetimeModifier;
-/*use bevy_hanabi::{
-    AccelModifier, ColorOverLifetimeModifier, EffectAsset, Gradient, PositionSphereModifier,
-    ShapeDimension, Spawner,
-};*/
+use bevy_hanabi::{
+    AccelModifier, Attribute, ColorOverLifetimeModifier, EffectAsset, Gradient, Module,
+    ParticleEffect, ParticleEffectBundle, SetAttributeModifier, SetPositionCircleModifier,
+    ShapeDimension, SizeOverLifetimeModifier, Spawner, SetVelocityCircleModifier
+};
 
 use fastrand;
 
@@ -24,7 +20,7 @@ impl Plugin for VfxPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<CameraShakeEvent>()
             .add_event::<ExplosionEvent>()
-            .add_systems(Update, shake_camera);
+            .add_systems(Update, (shake_camera, on_explosion_event));
     }
 }
 
@@ -65,102 +61,73 @@ fn shake_camera(
 fn on_explosion_event(
     mut events: EventReader<ExplosionEvent>,
     mut commands: Commands,
-    asset_server: Res<AssetServer>,
-) {
-    if events.is_empty() {
-        return;
-    }
-
-    /*for explosion_data in &mut events.iter(){
-        let particles = ParticleSystemBundle {
-            particle_system: ParticleSystem {
-                max_particles: 1000,
-                default_sprite: asset_server.load("textures/particles/px.png"),
-                spawn_rate_per_second: 200.0.into(),
-                initial_velocity: JitteredValue::jittered(100.0, -20.0..5.0),
-                lifetime: JitteredValue::jittered(0.35, -0.03..0.03),
-                color: ColorOverTime::Gradient(Gradient::new(vec![
-                    ColorPoint::new(Color::YELLOW, 0.0),
-                    ColorPoint::new(Color::rgba(1.0, 0.3, 0.0, 0.0), 1.0),
-                ])),
-                looping: false,
-                scale: ValueOverTime::from(10.0),
-                system_duration_seconds: 0.1,
-                ..ParticleSystem::default()
-            },
-            ..ParticleSystemBundle::default()
-        };
-
-        commands.spawn(
-            particles
-        ).insert(Playing).insert(Transform::from_translation(explosion_data.position));
-
-    }*/
-}
-
-// TODO: Hanabi doesn't work with wasm
-/*fn on_explosion_event(
-    mut events: EventReader<ExplosionEvent>,
-    mut commands: Commands,
     mut effects: ResMut<Assets<EffectAsset>>,
 ) {
     if events.is_empty() {
         return;
     }
 
-    for explosion_data in &mut events.iter() {
+    for explosion_data in &mut events.read() {
         // Define a color gradient
         let mut gradient = Gradient::new();
         gradient.add_key(0.0, Vec4::new(1., 0.8, 0., 1.)); // Orange
         gradient.add_key(1.0, Vec4::ZERO); // Transparent black
+        let mut module = Module::default();
+
+        let init_pos = SetPositionCircleModifier {
+            center: module.lit(Vec3::ZERO),
+            radius: module.lit(0.5),
+            dimension: ShapeDimension::Surface,
+            axis: module.lit(Vec3::new(0.0, 0.0, 1.0)),
+        };
+
+          // Also initialize a radial initial velocity
+        // away from the (same) sphere center.
+        let init_vel = SetVelocityCircleModifier {
+            center: module.lit(Vec3::ZERO),
+            axis: module.lit(Vec3::new(0., 0., 1.)),
+            speed: module.lit(400.0),
+        };
+
+
+        // Initialize the total lifetime of the particle, that is
+        // the time for which it's simulated and rendered. This modifier
+        // is almost always required, otherwise the particles won't show.
+        let lifetime = module.lit(explosion_data.lifetime); // literal value "10.0"
+        let init_lifetime = SetAttributeModifier::new(Attribute::LIFETIME, lifetime);
+
+        // Every frame, add a gravity-like acceleration downward
+        let accel = module.lit(Vec3::new(0., -1., 0.));
+        let update_accel = AccelModifier::new(accel);
 
         let mut size_gradient = Gradient::new();
-        size_gradient.add_key(0.0, Vec2::new(0.5, 0.5));
+        size_gradient.add_key(0.0, Vec2::new(3.0, 3.0));
         //size_gradient.add_key(0.8, Vec2::new(0.4,0.4));
-        size_gradient.add_key(1.0, Vec2::new(0.05,0.05));
-        let effect = effects.add(
-            EffectAsset {
-                name: "Blast".to_string(),
-                // Maximum number of particles alive at a time
-                capacity: 2000,
-                // Spawn at a rate of 25 particles per second
-                spawner: Spawner::rate(25.0.into()),
-                ..Default::default()
-            }
-            // On spawn, randomly initialize the position and velocity
-            // of the particle over a sphere of radius 0.5 units, with a
-            // radial initial velocity of 6 units/sec away from the
-            // sphere center.
-            .init(PositionCircleModifier {
-                center: Vec3::ZERO,
-                radius: 0.05,
-                dimension: ShapeDimension::Surface,
-                axis: Vec3::new(0.0, 0.0, 1.0),
-                speed: 12.0.into(),
-            })
-            .init(ParticleLifetimeModifier {
-                lifetime: explosion_data.lifetime,
-            })
-            // Every frame, add a gravity-like acceleration downward
-            .update(AccelModifier {
-                accel: Vec3::new(0., -0.2, 0.),
-            })
-            // Render the particles with a color gradient over their
-            // lifetime.
+        size_gradient.add_key(1.0, Vec2::new(0.05, 0.05));
+        let effect = EffectAsset::new(vec![2048], Spawner::rate(40.0.into()), module)// This rate is the count
+            .with_name("Blast")
+            .init(init_pos)
+            .init(init_vel)
+            .init(init_lifetime)
+            .update(update_accel)
             .render(ColorOverLifetimeModifier { gradient })
             .render(SizeOverLifetimeModifier {
                 gradient: size_gradient,
-            }),
-        );
+                ..default()
+            });
 
+        let effect_handle = effects.add(effect);
         commands
-            .spawn(bevy_hanabi::ParticleEffectBundle {
-                effect: ParticleEffect::new(effect),
+            .spawn(ParticleEffectBundle {
+                effect: ParticleEffect::new(effect_handle),
                 transform: Transform::from_translation(explosion_data.position),
                 ..Default::default()
             })
             .insert(TimedDespawn {
-                timer: Timer::new(Duration::from_secs_f32(explosion_data.lifetime), false),
+                timer: Timer::new(
+                    Duration::from_secs_f32(explosion_data.lifetime),
+                    TimerMode::Once
+                ),
             });
     }
-}*/
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,6 @@ fn main() {
         }))
         .add_plugins((GamePlugin, MenuPlugin))
         .init_state::<AppState>() //https://github.com/bevyengine/bevy/issues/14151
-
         .add_systems(Startup, setup_camera)
         .run();
 }
@@ -65,4 +64,3 @@ fn setup_camera(mut commands: Commands) {
         })
         .insert(CameraShaker { ..default() });
 }
-

--- a/src/menus/mod.rs
+++ b/src/menus/mod.rs
@@ -374,7 +374,6 @@ fn player_death_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
-
 fn load_background_model(mut commands: Commands, asset_server: ResMut<AssetServer>) {
     commands
         .spawn(SceneBundle {


### PR DESCRIPTION
Restored Bevy Hanabi plugin now that Hanabi works with WASM

There's no dedicated particle explosion event handling as of yet nor a dedicated particle component, so basically everything spouts particles on death.

This will be addressed in the future.